### PR TITLE
docs: update training READMEs for new RL features and streaming loop

### DIFF
--- a/src/fireworks/training/README.md
+++ b/src/fireworks/training/README.md
@@ -4,7 +4,7 @@
 It is split into two layers:
 
 - `sdk/`: infrastructure + orchestration primitives (trainer jobs, deployments, hotload, sampling).
-- `cookbook/`: compact, runnable training loops (GRPO, DPO, SFT) you can fork and modify.
+- `cookbook/`: compact, runnable training loops (GRPO, DAPO, GSPO, DPO, ORPO, SFT) you can fork and modify.
 
 ## Install
 
@@ -29,26 +29,53 @@ from fireworks.training.cookbook.utils import (
     InfraConfig,
     DeployConfig,
     HotloadConfig,
-    ISConfig,
 )
+from fireworks.training.cookbook.utils.rl import ISConfig
 
 cfg = Config(
     base_model="accounts/fireworks/models/qwen3-8b",
     max_rows=20,
     epochs=1,
-    group_size=4,
+    completions_per_prompt=4,
+    prompt_groups_per_step=4,
+    min_samples_per_fwd_bwd=16,
+    max_samples_per_fwd_bwd=64,
+    policy_loss="grpo",  # or "dapo", "gspo"
     infra=InfraConfig(region="US_OHIO_1"),
     deployment=DeployConfig(
         deployment_id="my-grpo-run",
         create_deployment=True,
-        tokenizer_model="Qwen/Qwen3-1.7B",
+        tokenizer_model="Qwen/Qwen3-8B",
     ),
     hotload=HotloadConfig(hot_load_interval=1),
-    tis_enabled=True,  # orthogonal -- works with any policy_loss
+    tis_enabled=True,
+    tis=ISConfig(clip_high=2.0, clip_low=0.0),
 )
 
 main(cfg)
 ```
+
+## Supported algorithms
+
+| Algorithm | Recipe | Reference model? | Description |
+| --- | --- | --- | --- |
+| GRPO | `rl_loop.py` | Yes | REINFORCE with group-relative advantages and KL penalty. |
+| DAPO | `rl_loop.py` | Yes | Asymmetric PPO clipping, no explicit KL penalty. |
+| GSPO | `rl_loop.py` | Yes | Sequence-level PPO clipping (geometric-mean ratio). |
+| DPO | `dpo_loop.py` | Yes (cached) | Direct preference optimization with concurrent reference caching. |
+| ORPO | `orpo_loop.py` | No | Odds-ratio preference optimization — combined SFT + odds-ratio loss. |
+| SFT | `sft_loop.py` | No | Supervised fine-tuning with response-only cross-entropy loss. |
+
+## Key features
+
+- **Streaming RL loop** — async rollout scheduling with greedy batching for maximum GPU utilization. Sampling, reference forward, and training overlap automatically.
+- **Pluggable policy losses** — swap between GRPO, DAPO, and GSPO via a single `policy_loss` string. CISPO available as a standalone loss function.
+- **TIS (Truncated Importance Sampling)** — orthogonal importance weighting composable with any policy loss.
+- **Router Replay (R3)** — replay MoE expert routing decisions from inference during training for MoE models.
+- **Training shape auto-config** — set `InfraConfig(training_shape_id="...")` to auto-derive region, accelerator, image tag, and node count from the control plane.
+- **Pipeline-parallel batch recommendation** — auto-computes optimal batch sizes for PP-enabled shapes.
+- **Pre-flight validation** — catches misconfiguration before GPU provisioning.
+- **Pluggable reward and filter** — customize `reward_fn` and `dynamic_filter_fn` without modifying the loop.
 
 ## Tinker mapping (mental model)
 
@@ -65,6 +92,7 @@ The key design is unchanged from Tinker: loss is computed on the client, while f
 
 - Want a runnable baseline: start with `cookbook/README.md`.
 - Want low-level lifecycle control: start with `sdk/README.md`.
+- Want a full worked example: see `cookbook/examples/deepmath/RUNBOOK.md`.
 
 ## Tests
 
@@ -72,4 +100,3 @@ The key design is unchanged from Tinker: loss is computed on the client, while f
 pytest src/fireworks/training/sdk/tests
 pytest src/fireworks/training/cookbook/tests
 ```
-

--- a/src/fireworks/training/cookbook/README.md
+++ b/src/fireworks/training/cookbook/README.md
@@ -7,24 +7,118 @@ Think of it like a Fireworks-adapted `tinker-cookbook`: same client-side loss pa
 
 | Recipe | File | Notes |
 | --- | --- | --- |
-| GRPO | `recipes/rl_loop.py` | Policy + reference trainers, deployment sampling, optional router replay (R3), optional truncated importance sampling (TIS). |
-| DPO | `recipes/dpo_loop.py` | Policy + reference trainers; reference logprobs are cached, then DPO loss is optimized. |
+| GRPO / DAPO / GSPO | `recipes/rl_loop.py` | Streaming RL loop with greedy rollout batching, pluggable policy loss, optional TIS and R3 router replay. |
+| DPO | `recipes/dpo_loop.py` | Policy + reference trainers; reference logprobs are cached concurrently, then DPO loss is optimized. |
+| ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization — no reference model needed. Combined SFT + odds-ratio loss. |
 | SFT | `recipes/sft_loop.py` | Single trainer with response-only cross-entropy loss. |
+
+## Streaming RL loop
+
+`rl_loop.py` uses a fully async, streaming architecture for maximum GPU utilization:
+
+1. Sampling coroutines run concurrently (capped by `max_concurrent`).
+2. Completions arrive into an `asyncio.Queue` as they finish.
+3. A dynamic filter rejects zero-variance reward groups (pluggable via `dynamic_filter_fn`).
+4. Valid groups accumulate in a greedy-batching buffer.
+5. When the buffer reaches `min_samples_per_fwd_bwd`, a micro-batch fires `ref_forward_batch` + `forward_backward_custom`.
+6. After `prompt_groups_per_step` groups are consumed, `optim_step` runs, followed by hotload/DCP save if scheduled.
+
+### Rollout scheduling parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `prompt_groups_per_step` | `1` | Prompt groups per optimizer step. |
+| `min_samples_per_fwd_bwd` | `None` (= max) | Minimum samples to trigger a `fwd_bwd` call. |
+| `max_samples_per_fwd_bwd` | `256` | Cap on samples per `fwd_bwd` call. |
+| `max_concurrent` | `32` | Max concurrent in-flight sampling requests. |
+
+The loop automatically computes `server_grad_accum_steps = ceil(prompt_groups_per_step / min_prompt_groups_per_fwd_bwd)`.
+
+## Policy loss variants
+
+All RL losses are set via `Config(policy_loss="...")` and are composable with TIS:
+
+| Loss | `policy_loss` value | Key config | Description |
+| --- | --- | --- | --- |
+| GRPO | `"grpo"` | `kl_beta` | REINFORCE with group-relative advantages and KL penalty. |
+| DAPO | `"dapo"` | `DAPOConfig` | PPO-style clipped surrogate with asymmetric clip bounds. No explicit KL penalty. |
+| GSPO | `"gspo"` | `GSPOConfig` | PPO clipping with a sequence-level importance ratio (geometric mean of per-token ratios). |
+
+CISPO (`make_cispo_loss_fn`) is also available as a standalone loss function via `fireworks.training.cookbook.utils.rl` but is not yet wired into the `policy_loss` dispatch. Use it directly when building a custom loop.
+
+### DAPO config (`DAPOConfig`)
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `eps_clip` | `0.2` | Lower clipping bound. |
+| `eps_clip_high` | `0.28` | Upper clipping bound. |
+| `eps_clip_c` | `None` | Optional dual-clip for negative-advantage tokens (must be > 1.0). |
+| `ratio_log_cap` | `20.0` | Clamp log-ratio before `exp()` for stability. |
+
+### GSPO config (`GSPOConfig`)
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `clip_ratio` | `0.2` | Symmetric fallback clip epsilon. |
+| `clip_ratio_low` | `None` | Asymmetric lower bound (overrides `clip_ratio`). |
+| `clip_ratio_high` | `None` | Asymmetric upper bound (overrides `clip_ratio`). |
+| `seq_ratio_log_cap` | `10.0` | Clamp sequence-level log-ratio. |
+| `kl_beta` | `0.001` | KL coefficient (metrics only). |
+
+### TIS — Truncated Importance Sampling (`ISConfig`)
+
+Orthogonal modifier composable with any policy loss. Enabled via `Config(tis_enabled=True)`.
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `clip_high` | `2.0` | Upper importance ratio clamp. |
+| `clip_low` | `0.0` | Lower importance ratio clamp. |
 
 ## Shared config blocks
 
 All recipes compose these dataclasses from `utils/config.py`:
 
-- `InfraConfig`: region, accelerators, image tag, extra args, node count.
-- `DeployConfig`: deployment lifecycle and sampling/hotload settings.
+- `InfraConfig`: region, accelerators, image tag, extra args, node count. Supports `training_shape_id` for auto-config from control-plane training shapes.
+- `DeployConfig`: deployment lifecycle, sampling/hotload settings, `tokenizer_model` (required for GRPO).
 - `HotloadConfig`: hotload cadence, base/delta behavior, timeout.
 - `ResumeConfig`: checkpoint source + optional step offset.
 - `WandBConfig`: optional experiment logging.
-- `ISConfig`: TIS (Truncated Importance Sampling) controls for GRPO.
-- `DAPOConfig`: DAPO asymmetric PPO clipping thresholds for GRPO.
-- `GSPOConfig`: GSPO sequence-level clipped-ratio PPO configuration for GRPO.
 
-## Minimal usage
+## Minimal usage — RL (GRPO)
+
+```python
+from fireworks.training.cookbook.recipes.rl_loop import Config, main
+from fireworks.training.cookbook.utils import (
+    InfraConfig,
+    DeployConfig,
+    HotloadConfig,
+)
+from fireworks.training.cookbook.utils.rl import ISConfig
+
+cfg = Config(
+    base_model="accounts/fireworks/models/qwen3-8b",
+    max_rows=20,
+    epochs=1,
+    completions_per_prompt=4,
+    prompt_groups_per_step=4,
+    min_samples_per_fwd_bwd=16,
+    max_samples_per_fwd_bwd=64,
+    policy_loss="grpo",  # or "dapo", "gspo"
+    infra=InfraConfig(region="US_OHIO_1"),
+    deployment=DeployConfig(
+        deployment_id="my-grpo-run",
+        create_deployment=True,
+        tokenizer_model="Qwen/Qwen3-8B",
+    ),
+    hotload=HotloadConfig(hot_load_interval=1),
+    tis_enabled=True,
+    tis=ISConfig(clip_high=2.0, clip_low=0.0),
+)
+
+main(cfg)
+```
+
+## Minimal usage — DPO
 
 ```python
 from fireworks.training.cookbook.recipes.dpo_loop import Config, main
@@ -41,11 +135,53 @@ cfg = Config(
 main(cfg)
 ```
 
+## Minimal usage — ORPO
+
+```python
+from fireworks.training.cookbook.recipes.orpo_loop import Config, main
+from fireworks.training.cookbook.utils import InfraConfig
+
+cfg = Config(
+    base_model="accounts/fireworks/models/qwen3-8b",
+    dataset="/path/to/preferences.jsonl",
+    tokenizer_model="Qwen/Qwen3-8B",
+    orpo_lambda=1.0,
+    epochs=1,
+    infra=InfraConfig(region="US_OHIO_1"),
+)
+
+main(cfg)
+```
+
+## Router Replay (R3) for MoE models
+
+Enable R3 to replay expert routing decisions from inference during training:
+
+```python
+cfg = Config(
+    ...,
+    router_replay=True,
+    router_replay_completion_only=True,  # default; replay only completion tokens
+)
+```
+
+Routing matrices from the deployment are aligned to training positions and injected into policy datums. Reference datums are token-only (no routing matrices).
+
+## Pipeline-parallel batch recommendation
+
+When using `InfraConfig(training_shape_id="...")` with a PP-enabled shape, the loop auto-computes and logs a `PPBatchRecommendation`:
+
+- `local_batch_size` — server-side PP batch size.
+- `bubble_ratio` — expected PP bubble fraction.
+- `recommended_group_size` — ideal `completions_per_prompt` to fill one PP batch.
+- `recommended_prompts_per_step` — optimal `prompt_groups_per_step`.
+
 ## What to customize first
 
 - Reward logic in `recipes/rl_loop.py` (`reward_fn`).
-- Loss functions in `utils/losses.py`, `utils/importance_sampling.py`, `utils/dapo.py`, and `utils/gspo.py`.
+- Loss functions in `utils/rl/` — `grpo.py`, `dapo.py`, `gspo.py`, `cispo.py`, `importance_sampling.py`.
 - Data adapters in `utils/data.py` for your JSONL schema.
+- Rollout filter via `dynamic_filter_fn` parameter to `run_rl_loop`.
 - Resume behavior in `utils/resume.py`.
 
 ## Relationship to SDK
@@ -58,4 +194,3 @@ The cookbook does not replace the SDK; it composes it:
 - token-in/token-out sampling: `DeploymentSampler`
 
 If you need a custom algorithm loop, copy the closest recipe and keep using the same SDK primitives.
-

--- a/src/fireworks/training/sdk/README.md
+++ b/src/fireworks/training/sdk/README.md
@@ -7,11 +7,23 @@ It provides trainer/deployment lifecycle APIs, hotload orchestration, and thin T
 
 | Component | Purpose |
 | --- | --- |
-| `TrainerJobManager` + `TrainerJobConfig` | Create/resume/delete RLOR trainer jobs and wait for healthy endpoints. |
-| `DeploymentManager` + `DeploymentConfig` | Create/get/delete deployments, hotload snapshots, wait for readiness, warmup. |
-| `DeploymentSampler` | Token-in/token-out completions wrapper with local tokenizer integration. |
-| `FiretitanServiceClient` + `FiretitanTrainingClient` | Tinker-compatible training clients with Fireworks-specific extensions. |
-| `WeightSyncer` | Save sampler checkpoints and sync them to deployments (base/delta chain). |
+| `TrainerJobManager` + `TrainerJobConfig` | Create/resume/delete RLOR trainer jobs and wait for healthy endpoints. Supports training shape resolution via `resolve_training_profile`. |
+| `DeploymentManager` + `DeploymentConfig` | Create/get/delete deployments, hotload snapshots, wait for readiness, warmup. Supports separate control-plane, inference, and hotload URLs. |
+| `DeploymentSampler` | Token-in/token-out completions wrapper with client-side tokenizer, echo mode, logprobs, and routing matrix extraction. |
+| `FiretitanServiceClient` + `FiretitanTrainingClient` | Tinker-compatible training clients with Fireworks-specific extensions (sampler weights, cross-job resume, session-scoped checkpoints). |
+| `WeightSyncer` | Save sampler checkpoints and sync them to deployments via delta chain management. |
+
+## Training shape resolution
+
+When using training shapes, the SDK resolves all infrastructure configuration from the control plane:
+
+```python
+mgr = TrainerJobManager(api_key="...", account_id="...", base_url="...")
+profile = mgr.resolve_training_profile("my-training-shape")
+# profile.region, profile.accelerator_type, profile.node_count, etc.
+```
+
+The resolved `TrainingShapeProfile` auto-populates region, accelerator, image tag, and node count. When a training shape is used, accelerator fields are omitted from the trainer API request (the control plane derives them from the shape).
 
 ## Tinker compatibility and extensions
 
@@ -19,7 +31,7 @@ Inherited behavior remains the same (`forward`, `forward_backward_custom`, `opti
 
 Fireworks-specific additions:
 
-- `save_weights_for_sampler_ext(name, checkpoint_type=...)`
+- `save_weights_for_sampler_ext(name, checkpoint_type=...)` — session-scoped sampler checkpoints with base/delta support.
 - `list_checkpoints()`
 - cross-job checkpoint references for resume (`resolve_checkpoint_path(...)`)
 - automatic model-input patch for router replay (`_tinker_r3_patch.py`)
@@ -70,6 +82,21 @@ syncer.save_and_hotload("step-1")
 syncer.save_dcp("step-1")
 ```
 
+## WeightSyncer lifecycle
+
+`WeightSyncer` manages the save-then-hotload pattern:
+
+| Method | Purpose |
+| --- | --- |
+| `save_and_hotload(name)` | Save sampler weights + hotload + warmup. |
+| `save_only(name)` | Save without hotloading (for split workflows). |
+| `hotload(snapshot_name)` | Hotload a previously saved snapshot. |
+| `save_dcp(name)` | Save DCP checkpoint for resume (independent of weight sync). |
+| `check_deployment_state()` | Query current hotload identity/readiness. |
+| `wait_for_hotload_ready(timeout_s)` | Block until hotload manager is initialized. |
+
+The syncer automatically manages the delta chain (`base_saved`/`base_identity`), forces full hotload when detecting stale deployment state, and tracks timing breakdowns via `last_timing`.
+
 ## Error handling and retries
 
 - `errors.py` provides `request_with_retries`, structured error formatting, and status hints.
@@ -78,5 +105,4 @@ syncer.save_dcp("step-1")
 
 ## Next step
 
-Use this layer directly when building your own algorithm loop, or use `fireworks.training.cookbook` for ready-to-run GRPO/DPO/SFT recipes.
-
+Use this layer directly when building your own algorithm loop, or use `fireworks.training.cookbook` for ready-to-run GRPO/DAPO/GSPO/DPO/ORPO/SFT recipes.


### PR DESCRIPTION
Reflect customer-facing changes: streaming RL loop with greedy rollout batching, new policy losses (DAPO, GSPO), ORPO recipe, training shape auto-config, R3 router replay, PP batch recommendation, and WeightSyncer lifecycle docs.

Made-with: Cursor