### PR TITLE
feat(training): add centralized cloud-aware path utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ training = [
   "tiktoken",
   "numpy",
   "wandb",
+  "fsspec",
+  "gcsfs",
+  "s3fs",
 ]
 
 [tool.rye]

--- a/src/fireworks/training/sdk/__init__.py
+++ b/src/fireworks/training/sdk/__init__.py
@@ -37,6 +37,12 @@ from fireworks.training.sdk.deployment import (
     DeploymentSampler,
     SampledCompletion,
 )
+from fireworks.training.sdk.path import (
+    cloud_join,
+    is_cloud_path,
+    open_path,
+    require_fsspec,
+)
 from fireworks.training.sdk.weight_syncer import WeightSyncer
 
 __all__ = [
@@ -60,4 +66,9 @@ __all__ = [
     "TrainerServiceEndpoint",
     "TrainingShapeProfile",
     "validate_output_model_id",
+    # Path utilities (cloud-aware I/O)
+    "cloud_join",
+    "is_cloud_path",
+    "open_path",
+    "require_fsspec",
 ]

--- a/src/fireworks/training/sdk/client.py
+++ b/src/fireworks/training/sdk/client.py
@@ -17,6 +17,7 @@ import logging
 from enum import Enum
 from dataclasses import dataclass
 
+from fireworks.training.sdk.path import is_cloud_path
 from tinker import types
 from tinker.lib.api_future_impl import _APIFuture
 from tinker.lib.queue_state_logger import QueueStateLogger
@@ -51,7 +52,7 @@ def make_cross_job_checkpoint_ref(*, source_job_id: str, checkpoint_name: str) -
         raise ValueError("source_job_id cannot be empty")
     if not normalized_checkpoint_name:
         raise ValueError("checkpoint_name cannot be empty")
-    if normalized_checkpoint_name.startswith("gs://") or normalized_checkpoint_name.startswith("/"):
+    if is_cloud_path(normalized_checkpoint_name) or normalized_checkpoint_name.startswith("/"):
         raise ValueError("checkpoint_name must be a logical checkpoint name, not a full path")
     return f"{CROSS_JOB_CHECKPOINT_REF_PREFIX}{normalized_source_job_id}/{normalized_checkpoint_name}"
 
@@ -275,8 +276,7 @@ class FiretitanTrainingClient(TrainingClient):
             Loadable checkpoint reference suitable for
             ``load_state_with_optimizer()``.
         """
-        # Already a full path -- nothing to resolve
-        if checkpoint_name.startswith("gs://") or checkpoint_name.startswith("/"):
+        if is_cloud_path(checkpoint_name) or checkpoint_name.startswith("/"):
             return checkpoint_name
 
         if source_job_id:

--- a/src/fireworks/training/sdk/path.py
+++ b/src/fireworks/training/sdk/path.py
@@ -1,0 +1,64 @@
+"""Cloud-aware path utilities for training data and checkpoints.
+
+Centralizes ``gs://`` and ``s3://`` handling so that recipe loops (cookbook)
+and SDK internals share consistent logic instead of duplicating inline
+fsspec checks and cloud-path concatenation.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import IO, Generator
+
+_CLOUD_SCHEMES = ("gs://", "s3://")
+
+try:
+    import fsspec
+    FSSPEC_AVAILABLE = True
+except ImportError:
+    fsspec = None  # type: ignore[assignment]
+    FSSPEC_AVAILABLE = False
+
+
+def is_cloud_path(path: str) -> bool:
+    """Return ``True`` if *path* is a ``gs://`` or ``s3://`` URI."""
+    return path.startswith(_CLOUD_SCHEMES)
+
+
+def require_fsspec() -> None:
+    """Raise ``ImportError`` with an actionable message when fsspec is absent."""
+    if not FSSPEC_AVAILABLE:
+        raise ImportError(
+            "fsspec is required for cloud paths (gs://, s3://). "
+            "Install with: pip install fsspec gcsfs s3fs"
+        )
+
+
+def cloud_join(base: str, *parts: str) -> str:
+    """Join path segments, preserving cloud URI schemes.
+
+    ``os.path.join`` mangles ``gs://bucket/dir`` into a local-looking path;
+    this helper concatenates with ``/`` for cloud URIs and falls back to
+    ``os.path.join`` for local paths.
+    """
+    if is_cloud_path(base):
+        return base.rstrip("/") + "/" + "/".join(p.strip("/") for p in parts)
+    return os.path.join(base, *parts)
+
+
+@contextmanager
+def open_path(path: str, mode: str = "r") -> Generator[IO, None, None]:
+    """Open a local file **or** cloud URI (``gs://``, ``s3://``) transparently.
+
+    Cloud paths are opened via :mod:`fsspec`; local paths use the built-in
+    :func:`open`.  Raises :class:`ImportError` if fsspec is needed but not
+    installed.
+    """
+    if is_cloud_path(path):
+        require_fsspec()
+        with fsspec.open(path, mode) as fh:
+            yield fh
+    else:
+        with open(path, mode) as fh:
+            yield fh

--- a/src/fireworks/training/sdk/tests/test_path.py
+++ b/src/fireworks/training/sdk/tests/test_path.py
@@ -1,0 +1,134 @@
+"""Tests for fireworks.training.sdk.path — cloud-aware path utilities."""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from fireworks.training.sdk.path import (
+    cloud_join,
+    is_cloud_path,
+    open_path,
+    require_fsspec,
+)
+
+
+# -- is_cloud_path ------------------------------------------------------------
+
+class TestIsCloudPath:
+    def test_gs(self):
+        assert is_cloud_path("gs://bucket/file.jsonl") is True
+
+    def test_s3(self):
+        assert is_cloud_path("s3://bucket/file.jsonl") is True
+
+    def test_local(self):
+        assert is_cloud_path("/tmp/data.jsonl") is False
+
+    def test_relative(self):
+        assert is_cloud_path("data/train.jsonl") is False
+
+    def test_http(self):
+        assert is_cloud_path("https://example.com/data.jsonl") is False
+
+
+# -- require_fsspec ------------------------------------------------------------
+
+class TestRequireFsspec:
+    def test_raises_when_unavailable(self):
+        with mock.patch("fireworks.training.sdk.path.FSSPEC_AVAILABLE", False):
+            with pytest.raises(ImportError, match="fsspec is required"):
+                require_fsspec()
+
+    def test_noop_when_available(self):
+        with mock.patch("fireworks.training.sdk.path.FSSPEC_AVAILABLE", True):
+            require_fsspec()
+
+
+# -- cloud_join ----------------------------------------------------------------
+
+class TestCloudJoin:
+    def test_gs_join(self):
+        assert cloud_join("gs://bucket/dir", "sub", "file.jsonl") == "gs://bucket/dir/sub/file.jsonl"
+
+    def test_gs_trailing_slash(self):
+        assert cloud_join("gs://bucket/dir/", "file.jsonl") == "gs://bucket/dir/file.jsonl"
+
+    def test_s3_join(self):
+        assert cloud_join("s3://bucket", "key") == "s3://bucket/key"
+
+    def test_local_join(self):
+        result = cloud_join("/tmp/logs", "checkpoints.jsonl")
+        assert result == os.path.join("/tmp/logs", "checkpoints.jsonl")
+
+    def test_local_with_multiple_parts(self):
+        result = cloud_join("/tmp", "a", "b")
+        assert result == os.path.join("/tmp", "a", "b")
+
+
+# -- open_path -----------------------------------------------------------------
+
+class TestOpenPath:
+    def test_local_read(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+            tmp.write("hello\nworld\n")
+            tmp_path = tmp.name
+
+        try:
+            with open_path(tmp_path) as f:
+                lines = f.readlines()
+            assert lines == ["hello\n", "world\n"]
+        finally:
+            os.unlink(tmp_path)
+
+    def test_local_write(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            with open_path(tmp_path, "w") as f:
+                f.write("written")
+            with open(tmp_path) as f:
+                assert f.read() == "written"
+        finally:
+            os.unlink(tmp_path)
+
+    def test_gs_delegates_to_fsspec(self):
+        fake_fh = io.StringIO("cloud data")
+        mock_cm = mock.MagicMock()
+        mock_cm.__enter__ = mock.Mock(return_value=fake_fh)
+        mock_cm.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch("fireworks.training.sdk.path.fsspec") as mock_fsspec, \
+             mock.patch("fireworks.training.sdk.path.FSSPEC_AVAILABLE", True):
+            mock_fsspec.open.return_value = mock_cm
+            with open_path("gs://bucket/file.txt") as f:
+                content = f.read()
+
+        assert content == "cloud data"
+        mock_fsspec.open.assert_called_once_with("gs://bucket/file.txt", "r")
+
+    def test_s3_delegates_to_fsspec(self):
+        fake_fh = io.StringIO("s3 data")
+        mock_cm = mock.MagicMock()
+        mock_cm.__enter__ = mock.Mock(return_value=fake_fh)
+        mock_cm.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch("fireworks.training.sdk.path.fsspec") as mock_fsspec, \
+             mock.patch("fireworks.training.sdk.path.FSSPEC_AVAILABLE", True):
+            mock_fsspec.open.return_value = mock_cm
+            with open_path("s3://bucket/file.txt") as f:
+                content = f.read()
+
+        assert content == "s3 data"
+        mock_fsspec.open.assert_called_once_with("s3://bucket/file.txt", "r")
+
+    def test_cloud_path_without_fsspec_raises(self):
+        with mock.patch("fireworks.training.sdk.path.FSSPEC_AVAILABLE", False):
+            with pytest.raises(ImportError, match="fsspec is required"):
+                with open_path("gs://bucket/file.txt"):
+                    pass


### PR DESCRIPTION
## Summary

- Add `fireworks.training.sdk.path` module centralizing all cloud-path handling (`gs://`, `s3://`) via fsspec
- Exports: `is_cloud_path`, `open_path`, `cloud_join`, `require_fsspec`
- Refactor `client.py` to use `is_cloud_path()` instead of inline `startswith("gs://")`
- Add `fsspec`, `gcsfs`, `s3fs` to `[training]` optional extras in `pyproject.toml`

### Motivation

Review feedback on [cookbook#240](https://github.com/fw-ai/cookbook/pull/240) flagged that cloud path logic (`_open_path`, fsspec checks, GCS path concatenation) was duplicated across `data.py` and `checkpoint_utils.py`. Moving it to the SDK level provides a single source of truth that both cookbook recipe loops and SDK internals share.

### New module: `fireworks.training.sdk.path`

| Function | Purpose |
|----------|---------|
| `is_cloud_path(path)` | Predicate for `gs://` / `s3://` URIs |
| `require_fsspec()` | Raises `ImportError` with actionable install instructions |
| `cloud_join(base, *parts)` | Path concatenation that preserves cloud URI schemes |
| `open_path(path, mode)` | Context manager: local `open()` or `fsspec.open()` transparently |

### Tests

14 unit tests in `test_path.py` covering all functions (cloud, local, missing-fsspec scenarios).

## Companion PR

- [cookbook#240](https://github.com/fw-ai/cookbook/pull/240) — consuming side (will import from SDK instead of inline)

## Test plan

- [x] `is_cloud_path` — gs://, s3://, local, relative, http
- [x] `require_fsspec` — raises when unavailable, noop when available
- [x] `cloud_join` — gs:// join, trailing slash, s3://, local fallback
- [x] `open_path` — local read/write, gs:// delegation, s3:// delegation, missing fsspec


Made with [Cursor](https://cursor.com)