### PR TITLE
fix: add missing loss types to LossFnType + reduce polling spam

### DIFF
--- a/src/fireworks/training/sdk/patches/__init__.py
+++ b/src/fireworks/training/sdk/patches/__init__.py
@@ -6,3 +6,4 @@ Remove individual patch files when tinker adds native support.
 
 import fireworks.training.sdk.patches._tinker_r3_patch  # noqa: F401
 import fireworks.training.sdk.patches._discriminator_patch  # noqa: F401
+import fireworks.training.sdk.patches._loss_fn_type_patch  # noqa: F401

--- a/src/fireworks/training/sdk/patches/_loss_fn_type_patch.py
+++ b/src/fireworks/training/sdk/patches/_loss_fn_type_patch.py
@@ -1,0 +1,62 @@
+"""Patch tinker's LossFnType to include loss functions added after the tinker release.
+
+Tinker's ``LossFnType`` is a ``Literal`` type alias that enumerates the
+server-supported builtin loss function names.  The firetitan backend adds
+new loss functions faster than tinker publishes releases, so the SDK client
+may reject valid loss names at Pydantic validation time.
+
+This patch replaces the ``LossFnType`` alias in the ``tinker.types``
+namespace with an expanded version that includes all server-supported names.
+
+Safe to import multiple times -- the patch is applied only once.
+Remove individual entries when tinker adds native support for them.
+"""
+
+import logging
+from typing import Literal
+
+from typing_extensions import TypeAlias
+
+logger = logging.getLogger(__name__)
+
+_SENTINEL = "_loss_fn_type_patch_applied"
+
+# All loss function names supported by the firetitan backend.
+# Keep in sync with train-firetitan-py/firetitan/train/rlor/tinker_schemas.py
+PatchedLossFnType: TypeAlias = Literal[
+    "cross_entropy",
+    "importance_sampling",
+    "ppo",
+    "cispo",
+    "dapo",
+    "gspo",
+    "dro",
+    "kl_distillation",
+]
+
+
+def _apply_loss_fn_type_patch() -> None:
+    import tinker.types.loss_fn_type as loss_fn_type_module
+    from tinker.types.forward_backward_input import ForwardBackwardInput
+
+    if getattr(loss_fn_type_module, _SENTINEL, False):
+        return
+
+    old_type = loss_fn_type_module.LossFnType
+    loss_fn_type_module.LossFnType = PatchedLossFnType
+
+    # Update ForwardBackwardInput's field annotation so Pydantic validates
+    # against the expanded type.
+    ForwardBackwardInput.model_fields["loss_fn"].annotation = PatchedLossFnType
+    ForwardBackwardInput.__annotations__["loss_fn"] = PatchedLossFnType
+    ForwardBackwardInput.model_rebuild(force=True)
+
+    setattr(loss_fn_type_module, _SENTINEL, True)
+    logger.info(
+        "LossFnType patch applied: expanded from %s to %s",
+        old_type,
+        PatchedLossFnType,
+    )
+
+
+_apply_loss_fn_type_patch()

--- a/src/fireworks/training/sdk/tests/test_loss_fn_type_patch.py
+++ b/src/fireworks/training/sdk/tests/test_loss_fn_type_patch.py
@@ -1,0 +1,76 @@
+"""Tests for the LossFnType patch that adds missing builtin loss names."""
+
+from typing import get_args
+
+
+class TestLossFnTypePatch:
+    """Verify that the LossFnType patch adds server-supported loss names."""
+
+    def test_gspo_in_loss_fn_type(self):
+        """'gspo' should be in the patched LossFnType."""
+        import tinker.types.loss_fn_type as mod
+
+        allowed = get_args(mod.LossFnType)
+        assert "gspo" in allowed, f"gspo not in LossFnType: {allowed}"
+
+    def test_dapo_in_loss_fn_type(self):
+        """'dapo' should be in the patched LossFnType."""
+        import tinker.types.loss_fn_type as mod
+
+        allowed = get_args(mod.LossFnType)
+        assert "dapo" in allowed, f"dapo not in LossFnType: {allowed}"
+
+    def test_kl_distillation_in_loss_fn_type(self):
+        """'kl_distillation' should be in the patched LossFnType."""
+        import tinker.types.loss_fn_type as mod
+
+        allowed = get_args(mod.LossFnType)
+        assert "kl_distillation" in allowed, f"kl_distillation not in LossFnType: {allowed}"
+
+    def test_original_types_still_present(self):
+        """Original loss types should still be valid."""
+        import tinker.types.loss_fn_type as mod
+
+        allowed = get_args(mod.LossFnType)
+        for expected in ("cross_entropy", "importance_sampling", "ppo", "cispo", "dro"):
+            assert expected in allowed, f"{expected} not in LossFnType: {allowed}"
+
+    def test_forward_backward_input_accepts_gspo(self):
+        """ForwardBackwardInput should validate with loss_fn='gspo'."""
+        from tinker.types.datum import Datum
+        from tinker.types.model_input import ModelInput
+        from tinker.types.forward_backward_input import ForwardBackwardInput
+        from tinker.types.tensor_data import TensorData
+
+        mi = ModelInput.from_ints([1, 2, 3])
+        loss_fn_inputs = {"weights": TensorData(data=[1.0, 1.0, 1.0], dtype="float32")}
+        datum = Datum(model_input=mi, loss_fn_inputs=loss_fn_inputs)
+        fbi = ForwardBackwardInput(data=[datum], loss_fn="gspo")
+        assert fbi.loss_fn == "gspo"
+
+    def test_forward_backward_input_accepts_dapo(self):
+        """ForwardBackwardInput should validate with loss_fn='dapo'."""
+        from tinker.types.datum import Datum
+        from tinker.types.model_input import ModelInput
+        from tinker.types.forward_backward_input import ForwardBackwardInput
+        from tinker.types.tensor_data import TensorData
+
+        mi = ModelInput.from_ints([1, 2, 3])
+        loss_fn_inputs = {"weights": TensorData(data=[1.0, 1.0, 1.0], dtype="float32")}
+        datum = Datum(model_input=mi, loss_fn_inputs=loss_fn_inputs)
+        fbi = ForwardBackwardInput(data=[datum], loss_fn="dapo")
+        assert fbi.loss_fn == "dapo"
+
+    def test_idempotent_double_apply(self):
+        """Calling the patch function twice should not break anything."""
+        from fireworks.training.sdk.patches._loss_fn_type_patch import (
+            _apply_loss_fn_type_patch,
+        )
+
+        _apply_loss_fn_type_patch()  # second call
+
+        import tinker.types.loss_fn_type as mod
+
+        allowed = get_args(mod.LossFnType)
+        assert "gspo" in allowed
+        assert "cross_entropy" in allowed

--- a/src/fireworks/training/sdk/trainer.py
+++ b/src/fireworks/training/sdk/trainer.py
@@ -342,6 +342,10 @@ class TrainerJobManager(FireworksClient):
         except Exception:
             return False
 
+    # Minimum interval (seconds) between identical-state polling log lines.
+    # State *changes* are always logged immediately.
+    _POLL_LOG_THROTTLE_S: float = 30.0
+
     def _poll_until_ready(
         self,
         job_id: str,
@@ -352,6 +356,8 @@ class TrainerJobManager(FireworksClient):
         start = time.time()
         service_ready = False
         base_url = self._get_trainer_gateway_url(job_id)
+        last_state = ""
+        last_log_time = 0.0
 
         while time.time() - start < timeout_s:
             job = self.get(job_id)
@@ -385,20 +391,28 @@ class TrainerJobManager(FireworksClient):
                 )
                 return TrainerServiceEndpoint(job_name=job_name, job_id=job_id, base_url=base_url)
 
-            if state == "JOB_STATE_RUNNING":
-                logger.info(
-                    "[%ds] Trainer job %s: state=%s, healthz=waiting",
-                    elapsed,
-                    job_id,
-                    state,
-                )
-            else:
-                logger.info(
-                    "[%ds] Trainer job %s: state=%s",
-                    elapsed,
-                    job_id,
-                    state,
-                )
+            # Log on state change or every _POLL_LOG_THROTTLE_S seconds to
+            # avoid flooding the console with 60+ identical lines (FIR2-1201).
+            now = time.time()
+            state_changed = state != last_state
+            throttle_elapsed = (now - last_log_time) >= self._POLL_LOG_THROTTLE_S
+            if state_changed or throttle_elapsed:
+                if state == "JOB_STATE_RUNNING":
+                    logger.info(
+                        "[%ds] Trainer job %s: state=%s, healthz=waiting",
+                        elapsed,
+                        job_id,
+                        state,
+                    )
+                else:
+                    logger.info(
+                        "[%ds] Trainer job %s: state=%s",
+                        elapsed,
+                        job_id,
+                        state,
+                    )
+                last_state = state
+                last_log_time = now
 
             time.sleep(poll_interval_s)
 


### PR DESCRIPTION
## Summary

Two fixes for tinker dogfooding feedback (FIR2-1115):

### 1. Add missing loss types to LossFnType (FIR2-1214)

The tinker package's `LossFnType` Literal is missing `'gspo'`, `'dapo'`, and `'kl_distillation'` — all supported by the firetitan backend (`tinker_schemas.py`). This causes Pydantic validation to reject `forward_backward('gspo')` at the client, **blocking all GSPO training**.

Added `_loss_fn_type_patch.py` that monkey-patches tinker's `LossFnType` at SDK import time, following the same pattern as the existing `_discriminator_patch.py` and `_tinker_r3_patch.py`.

7 new tests verify the patch works for all added types and is idempotent.

### 2. Reduce trainer provisioning polling log spam (FIR2-1201)

`_poll_until_ready()` previously logged at every 5s poll interval, producing **60+ identical lines** over a ~5 minute provisioning window. Now only logs on state changes or every 30s, reducing noise from ~60 lines to ~10 while still showing all state transitions immediately.

## Changes

| File | What changed |
|------|-------------|
| `patches/_loss_fn_type_patch.py` | New patch: extends tinker `LossFnType` with `gspo`, `dapo`, `kl_distillation` |
| `patches/__init__.py` | Import new patch at SDK init time |
| `trainer.py` | Throttle identical-state polling logs to every 30s (state changes still immediate) |
| `tests/test_loss_fn_type_patch.py` | 7 new tests for the LossFnType patch |

## Testing

All 109 SDK tests pass (2 pre-existing failures in test_deployment.py excluded — `DeploymentInfo.deployment_shape_version` attribute mismatch).