### PR TITLE
chore: promote sdk from fireworks staging

### DIFF
--- a/src/fireworks/training/sdk/deployment.py
+++ b/src/fireworks/training/sdk/deployment.py
@@ -174,6 +174,7 @@ class DeploymentConfig:
     disable_speculative_decoding: bool = False
     extra_args: list[str] | None = None
     extra_values: dict[str, str] | None = None
+    annotations: dict[str, str] | None = None
 
 
 class DeploymentManager(_RestClient):
@@ -299,6 +300,7 @@ class DeploymentManager(_RestClient):
             "minReplicaCount": config.min_replica_count,
             "maxReplicaCount": config.max_replica_count,
             "enableHotLoad": True,
+            "forTraining": True,
         }
         if config.region:
             body["placement"] = {"region": config.region}
@@ -317,6 +319,8 @@ class DeploymentManager(_RestClient):
             body["extraArgs"] = flat
         if config.extra_values:
             body["extraValues"] = config.extra_values
+        if config.annotations:
+            body["annotations"] = config.annotations
 
         logger.info("Creating deployment: %s", config.deployment_id)
         resp = self._post(path, json=body)

--- a/src/fireworks/training/sdk/tests/test_deployment.py
+++ b/src/fireworks/training/sdk/tests/test_deployment.py
@@ -127,7 +127,9 @@ class TestCreateDeployment:
         mgr._post = MagicMock(return_value=resp)
         mgr._create_deployment(deploy_config)
         path = mgr._post.call_args[0][0]
+        body = mgr._post.call_args[1]["json"]
         assert "/deployments" in path
+        assert body["forTraining"] is True
 
     def test_create_omits_placement_when_region_unset(self, mgr):
         resp = MagicMock()
@@ -148,6 +150,27 @@ class TestCreateDeployment:
 
         body = mgr._post.call_args[1]["json"]
         assert "placement" not in body
+
+    def test_create_includes_annotations(self, mgr):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.is_success = True
+        resp.json.return_value = {
+            "name": "accounts/test-acct/deployments/dep-1",
+            "state": "CREATING",
+        }
+        mgr._post = MagicMock(return_value=resp)
+
+        mgr._create_deployment(
+            DeploymentConfig(
+                deployment_id="dep-1",
+                base_model="accounts/test/models/qwen3-1p7b",
+                annotations={"purpose": "test"},
+            )
+        )
+
+        body = mgr._post.call_args[1]["json"]
+        assert body["annotations"] == {"purpose": "test"}
 
     def test_409_is_not_raised(self, mgr, deploy_config):
         resp = MagicMock()


### PR DESCRIPTION
Issue: cookbook training setup needs the SDK to carry the public deployment request field instead of using raw request plumbing.

Resolution: promote the staged SDK change that adds the deployment config field and request serialization test.

Validation: CI will run on this PR.