### PR TITLE
ci: fix smoke test against new release + tag release PRs after publish

### DIFF
--- a/.github/workflows/post-publish.yml
+++ b/.github/workflows/post-publish.yml
@@ -22,8 +22,12 @@ jobs:
 
       - name: Wait for PyPI propagation and install
         run: |
+          # --upgrade --pre is required: the runner toolcache ships an older
+          # fireworks-ai which would otherwise satisfy the requirement and skip
+          # the install, so the smoke test would silently exercise the stale
+          # cached version instead of the release we just published.
           for i in $(seq 1 10); do
-            if pip install fireworks-ai 2>/dev/null; then
+            if pip install --upgrade --pre fireworks-ai 2>/dev/null; then
               echo "Package available"
               exit 0
             fi
@@ -39,5 +43,5 @@ jobs:
       - name: Verify training extras
         if: matrix.python-version != '3.9'
         run: |
-          pip install "fireworks-ai[training]"
+          pip install --upgrade --pre "fireworks-ai[training]"
           python -c "from fireworks.training import sdk; print('Training SDK OK')"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -119,3 +119,24 @@ jobs:
             --title "${TAG}" \
             --notes-file "${notes_file}" \
             ${prerelease_flag}
+
+      - name: Mark release PR as tagged
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FW_AI_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Find the PR that was squash-merged to produce this release commit
+          # and flip the autorelease labels: pending -> tagged.
+          # Failure here is informational only — the tag and GitHub Release
+          # are already created and the next workflow listening on Release
+          # has fired.
+          pr_number="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [[ -z "${pr_number}" ]]; then
+            echo "No PR association for ${GITHUB_SHA}; skipping label update."
+            exit 0
+          fi
+          gh pr edit "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+            --remove-label "autorelease: pending" \
+            --add-label "autorelease: tagged" || true


### PR DESCRIPTION
## Summary

Two independent CI improvements on the release workflows:

- **`post-publish.yml`** — `pip install --upgrade --pre` so the smoke test exercises the just-published wheel. Without `--upgrade --pre`, an older `fireworks-ai` in the GitHub Actions runner toolcache already satisfies the requirement, so `pip install` short-circuits and the smoke test silently validates the cached version instead of the new release.

- **`release-tag.yml`** — after the git tag and GitHub Release are created, flip the release PR's `autorelease` label from `pending` to `tagged` so the PR's state reflects the publish chain's progress. The step is gated on the previous tag/release step's success (default per-step `if: success()`), so a failed tag/release leaves the PR labeled `pending`.

## Test plan

- [ ] Manually dispatch `Release Tag` against a recent release commit on a fork and confirm: (1) tag/release re-creation is idempotent (skipped if tag exists); (2) on a fresh release, the release PR's `autorelease: pending` is removed and `autorelease: tagged` is added.
- [ ] Next release cycle: confirm the post-publish smoke test installs the new version (check log line `fireworks-ai <new_version> installed successfully`) rather than a stale cached one.