### PR TITLE
Use PYPI_TOKEN as the sole PyPI publish secret

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           bash ./bin/publish-pypi
         env:
-          FIREWORKS_PYPI_TOKEN: ${{ secrets.FIREWORKS_PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           bash ./bin/publish-pypi
         env:
-          PYPI_TOKEN: ${{ secrets.FIREWORKS_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+          FIREWORKS_PYPI_TOKEN: ${{ secrets.FIREWORKS_PYPI_TOKEN }}

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -18,4 +18,4 @@ jobs:
         run: |
           bash ./bin/check-release-environment
         env:
-          FIREWORKS_PYPI_TOKEN: ${{ secrets.FIREWORKS_PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -18,4 +18,4 @@ jobs:
         run: |
           bash ./bin/check-release-environment
         env:
-          PYPI_TOKEN: ${{ secrets.FIREWORKS_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+          FIREWORKS_PYPI_TOKEN: ${{ secrets.FIREWORKS_PYPI_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,9 @@ the changes aren't made through the automated pipeline, you may want to make rel
 
 ### Publish with a GitHub workflow
 
-You can release to package managers by using [the `Publish PyPI` GitHub action](https://www.github.com/fw-ai-external/python-sdk/actions/workflows/publish-pypi.yml). This requires a setup organization or repository secret to be set up.
+You can release to package managers by using [the `Publish PyPI` GitHub action](https://www.github.com/fw-ai-external/python-sdk/actions/workflows/publish-pypi.yml). This requires the `FIREWORKS_PYPI_TOKEN` organization or repository Actions secret to be set.
 
 ### Publish manually
 
-If you need to manually release a package, you can run the `bin/publish-pypi` script with a `PYPI_TOKEN` set on
+If you need to manually release a package, you can run the `bin/publish-pypi` script with `FIREWORKS_PYPI_TOKEN` set on
 the environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,9 @@ the changes aren't made through the automated pipeline, you may want to make rel
 
 ### Publish with a GitHub workflow
 
-You can release to package managers by using [the `Publish PyPI` GitHub action](https://www.github.com/fw-ai-external/python-sdk/actions/workflows/publish-pypi.yml). This requires the `FIREWORKS_PYPI_TOKEN` organization or repository Actions secret to be set.
+You can release to package managers by using [the `Publish PyPI` GitHub action](https://www.github.com/fw-ai-external/python-sdk/actions/workflows/publish-pypi.yml). This requires the `PYPI_TOKEN` organization or repository Actions secret to be set.
 
 ### Publish manually
 
-If you need to manually release a package, you can run the `bin/publish-pypi` script with `FIREWORKS_PYPI_TOKEN` set on
+If you need to manually release a package, you can run the `bin/publish-pypi` script with `PYPI_TOKEN` set on
 the environment.

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${PYPI_TOKEN}" ]; then
-  errors+=("The PYPI_TOKEN secret has not been set. Please set it in either this repository's secrets or your organization secrets.")
+if [ -z "${FIREWORKS_PYPI_TOKEN:-}" ]; then
+  errors+=("The FIREWORKS_PYPI_TOKEN secret has not been set. Please set it in either this repository's Actions secrets or organization Actions secrets.")
 fi
 
 lenErrors=${#errors[@]}

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${FIREWORKS_PYPI_TOKEN:-}" ]; then
-  errors+=("The FIREWORKS_PYPI_TOKEN secret has not been set. Please set it in either this repository's Actions secrets or organization Actions secrets.")
+if [ -z "${PYPI_TOKEN:-}" ]; then
+  errors+=("The PYPI_TOKEN secret has not been set. Please set it in either this repository's Actions secrets or organization Actions secrets.")
 fi
 
 lenErrors=${#errors[@]}

--- a/bin/publish-pypi
+++ b/bin/publish-pypi
@@ -3,4 +3,4 @@
 set -euo pipefail
 mkdir -p dist
 rye build --clean
-rye publish --yes --token="$FIREWORKS_PYPI_TOKEN"
+rye publish --yes --token="$PYPI_TOKEN"

--- a/bin/publish-pypi
+++ b/bin/publish-pypi
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -euo pipefail
 mkdir -p dist
 rye build --clean
-rye publish --yes --token=$PYPI_TOKEN
+rye publish --yes --token="$FIREWORKS_PYPI_TOKEN"


### PR DESCRIPTION
Closed to avoid diverging from the staged public-repos workflow. The source-of-truth change should land through the staging PR in `fw-ai/fireworks`:

https://github.com/fw-ai/fireworks/pull/28135

This PR was only opened as an immediate direct public-repo patch, but we should not keep both paths active.