### PR TITLE
fix(sdk): surface gateway errors, fail-fast on quota 429s, fix readiness + max-context

### DIFF
--- a/src/fireworks/training/sdk/client.py
+++ b/src/fireworks/training/sdk/client.py
@@ -2176,9 +2176,19 @@ class FiretitanServiceClient(ServiceClient):
         # reads None). Mirror managed_trainer_job_id's handle-first lookup.
         if self._managed_handle is not None and self._managed_handle.max_context_length is not None:
             return self._managed_handle.max_context_length
-        if self._managed_config is None:
-            return None
-        return self._managed_config.max_context_length
+        if self._managed_config is not None and self._managed_config.max_context_length is not None:
+            return self._managed_config.max_context_length
+        # Defensive fallback: under backend auto-shape selection the resolved
+        # max context length is computed on the child trainer job and may not be
+        # surfaced onto the handle/config, leaving this None and hard-failing in
+        # _require_managed_value even though the training shape itself carries a
+        # valid limit (the 2026-06-28 SDK-managed max-context incident). Fall
+        # back to the shape profile's max_supported_context_length when present.
+        profile = self.managed_training_profile
+        shape_max = getattr(profile, "max_supported_context_length", None)
+        if shape_max:
+            return shape_max
+        return None
 
     @property
     def managed_deployment_shape(self) -> str | None:

--- a/src/fireworks/training/sdk/errors.py
+++ b/src/fireworks/training/sdk/errors.py
@@ -12,6 +12,7 @@ Provides:
 from __future__ import annotations
 
 import time
+import random
 import asyncio
 import logging
 from typing import Any, Tuple, Callable, Awaitable
@@ -92,13 +93,79 @@ def _is_retryable_status_code(status_code: int) -> bool:
     return status_code in RETRYABLE_STATUS_CODES
 
 
-def _backoff_delay(attempt: int, start_time: float, max_wait_time: float) -> float | None:
-    """Return delay in seconds, or None if budget exhausted."""
+def _backoff_delay(
+    attempt: int,
+    start_time: float,
+    max_wait_time: float,
+    retry_after: float | None = None,
+) -> float | None:
+    """Return delay in seconds (with jitter), or None if the budget is exhausted.
+
+    When the server supplies a ``Retry-After`` we honor it as the base delay;
+    otherwise we use capped exponential backoff. Equal jitter (50-100% of the
+    base) is applied so that many concurrent jobs don't retry in lockstep and
+    stampede the API (the synchronized-retry-storm seen in the 2026-06-28
+    trainer-create 429 incident).
+    """
     elapsed = time.time() - start_time
     if elapsed >= max_wait_time:
         return None
-    delay = min(2 ** attempt, 30)
-    return min(delay, start_time + max_wait_time - time.time())
+    if retry_after is not None and retry_after >= 0:
+        base = float(retry_after)
+    else:
+        base = float(min(2 ** attempt, 30))
+    base = max(base, 0.0)
+    delay = base * 0.5 + base * 0.5 * random.random()  # equal jitter: 50-100% of base
+    remaining = start_time + max_wait_time - time.time()
+    if remaining <= 0:
+        return None
+    return min(delay, remaining)
+
+
+def _retry_after_seconds(resp) -> float | None:
+    """Parse a ``Retry-After`` header (delay-seconds or HTTP-date), if present."""
+    headers = getattr(resp, "headers", None) or {}
+    try:
+        val = headers.get("Retry-After") or headers.get("retry-after")
+    except Exception:
+        return None
+    if not val:
+        return None
+    try:
+        return max(0.0, float(val))
+    except (TypeError, ValueError):
+        pass
+    try:
+        from email.utils import parsedate_to_datetime
+        from datetime import datetime, timezone
+
+        dt = parsedate_to_datetime(val)
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
+    except Exception:
+        return None
+    return None
+
+
+def _is_nonretryable_quota_429(resp) -> bool:
+    """True for a 429 with no ``Retry-After`` whose body indicates quota exhaustion.
+
+    Training GPU quota does not free within the retry budget (~5 min), so
+    retrying a quota 429 just produces a futile request storm and the same
+    failure. We surface it immediately instead. A 429 that carries an explicit
+    ``Retry-After`` is treated as transient (rate limit) and still retried.
+    """
+    if getattr(resp, "status_code", None) != 429:
+        return False
+    if _retry_after_seconds(resp) is not None:
+        return False
+    try:
+        msg = parse_api_error(resp).lower()
+    except Exception:
+        return False
+    return "quota" in msg or "resource_exhausted" in msg or "resource exhausted" in msg
 
 
 def request_with_retries(
@@ -128,7 +195,12 @@ def request_with_retries(
             raise
 
         if _is_retryable_status_code(resp.status_code):
-            delay = _backoff_delay(attempt, start, max_wait_time)
+            if _is_nonretryable_quota_429(resp):
+                # Quota exhaustion is not transient on this horizon; surface it
+                # to the caller instead of retrying futilely.
+                return resp
+            retry_after = _retry_after_seconds(resp)
+            delay = _backoff_delay(attempt, start, max_wait_time, retry_after=retry_after)
             if delay is not None:
                 attempt += 1
                 logger.debug("HTTP %d (attempt %d), retrying in %.1fs", resp.status_code, attempt, delay)
@@ -160,7 +232,10 @@ async def async_request_with_retries(
             raise
 
         if _is_retryable_status_code(resp.status_code):
-            delay = _backoff_delay(attempt, start, max_wait_time)
+            if _is_nonretryable_quota_429(resp):
+                return resp
+            retry_after = _retry_after_seconds(resp)
+            delay = _backoff_delay(attempt, start, max_wait_time, retry_after=retry_after)
             if delay is not None:
                 attempt += 1
                 logger.debug("HTTP %d (attempt %d), retrying in %.1fs", resp.status_code, attempt, delay)

--- a/src/fireworks/training/sdk/trainer.py
+++ b/src/fireworks/training/sdk/trainer.py
@@ -435,7 +435,21 @@ class TrainerJobManager(FireworksClient):
                 return existing
         if not resp.is_success:
             self._log_create_failure(resp)
-        resp.raise_for_status()
+            # Raise the parsed gateway reason (quota exceeded / invalid
+            # accelerator-region / "Only superuser can skip validations" / …)
+            # so the job's status_message is self-describing, instead of a bare
+            # httpx ``raise_for_status`` that drops the response body and makes
+            # a customer config/quota error look like an opaque backend failure.
+            error_msg, solution = self._create_failure_details(resp)
+            raise RuntimeError(
+                format_sdk_error(
+                    f"RLOR job creation failed (HTTP {resp.status_code})",
+                    error_msg,
+                    solution,
+                    docs_url=DOCS_SDK,
+                    show_support=resp.status_code >= 500,
+                )
+            )
         return resp.json()
 
     @staticmethod
@@ -628,6 +642,30 @@ class TrainerJobManager(FireworksClient):
                         f"  Console: {CONSOLE_URL}",
                         docs_url=DOCS_SDK,
                         show_support=True,
+                    )
+                )
+
+            # Other terminal states must short-circuit too: otherwise a job that
+            # was cancelled/deleted/completed before becoming ready keeps getting
+            # polled until the full timeout and then surfaces a misleading
+            # "did not become ready within {timeout}s" (the 2026-06-28 readiness-
+            # timeout incident). Raise immediately with the job's own detail.
+            if state in (
+                "JOB_STATE_CANCELLED",
+                "JOB_STATE_DELETING",
+                "JOB_STATE_DELETED",
+                "JOB_STATE_COMPLETED",
+            ):
+                msg = status_message or state
+                raise RuntimeError(
+                    format_sdk_error(
+                        f"Trainer job {job_id} entered terminal state {state} before becoming ready",
+                        msg,
+                        "The trainer was cancelled, deleted, or completed before it reached a healthy "
+                        "serving state -- usually external cancellation, preemption, or never being "
+                        "scheduled (e.g. insufficient capacity). Check trainer status and events in the "
+                        f"Fireworks console.\n  Console: {CONSOLE_URL}",
+                        docs_url=DOCS_SDK,
                     )
                 )
 


### PR DESCRIPTION
## Description

Implements the SDK-side fixes from the 2026-06-28 FireOptimizer alert RCAs (#oncall-fireoptimizer). Each addresses a class where a customer-side condition surfaced as an opaque backend/trainer failure.

### Changes
- **`trainer._create`** — raise the parsed gateway reason instead of a bare `raise_for_status()` that drops the body. Trainer-create 429/400s now have a self-describing `status_message` (`quota exceeded`, `invalid accelerator/region`, `Only superuser can skip validations`, …) instead of an MDN 400 link. (Removes the need for downstream attribution heuristics.)
- **`errors.request_with_retries`** — don't futilely retry quota `429`s (`RESOURCE_EXHAUSTED` with no `Retry-After`) — they don't free within the ~5 min budget and just create a retry storm; **honor `Retry-After`**; add **equal jitter** (50–100% of base) so concurrent jobs don't retry in lockstep. Applied to sync + async.
- **`trainer._poll_until_ready`** — treat `JOB_STATE_CANCELLED/DELETING/DELETED/COMPLETED` as terminal and raise with the job's detail, instead of polling a dead job until the misleading `did not become ready within 3600s`.
- **`client.managed_max_context_length`** — fall back to the training shape profile's `max_supported_context_length` when the handle/config don't carry it, so a managed SFT/DPO run under backend auto-shape selection doesn't hard-fail in `_require_managed_value`. (Defensive complement to the in-flight cookbook/CP surfacing fixes.)

## Diagram

```mermaid
flowchart TD
  C[trainer._create non-2xx] -->|before| Bare[raise_for_status: body dropped → opaque]
  C -->|after| Real[raise parsed gateway reason → self-describing]
  R[retry loop sees 429] -->|quota, no Retry-After| Fast[fail fast, surface]
  R -->|transient| JJ[backoff + jitter, honor Retry-After]
  P[_poll_until_ready] -->|CANCELLED/DELETED/COMPLETED| Term[raise with job detail]
  P -->|else timeout| TO[3600s timeout]
  M[managed_max_context_length None] --> FB[fallback: shape profile max_supported_context_length]
```

## Reviewer Ask
- **Review focus:** the quota-429 detection heuristic (`_is_nonretryable_quota_429`) and the jitter/`Retry-After` change to the shared retry loop; the terminal-state set in `_poll_until_ready`.
- **Manual repro:** `py_compile` + lints clean; full unit run needs the SDK deps (`tinker`, …) installed.

## Type of Change
- [x] Bug fix

Made with [Cursor](https://cursor.com)