### PR TITLE
feat(training-sdk): submit confirmed support tickets

### DIFF
--- a/src/fireworks/training/sdk/client.py
+++ b/src/fireworks/training/sdk/client.py
@@ -2604,6 +2604,35 @@ class FiretitanServiceClient(ServiceClient):
             return None
         return super().get_telemetry()
 
+    def create_support_ticket(
+        self,
+        *,
+        question_type: str,
+        subject: str,
+        description: str,
+        account_id: str | None = None,
+        resource_name: str | None = None,
+        error_reason: str | None = None,
+        request_id: str | None = None,
+        user_confirmed: bool = False,
+    ) -> dict:
+        """Submit reviewed support fields through the Fireworks control plane."""
+        from fireworks.training.sdk.fireworks_client import FireworksClient
+
+        api_key = self._require_fireworks_api_key("support ticket submission")
+        base_url = _fireworks_api_root_url(getattr(self, "_managed_base_url", None))
+        with FireworksClient(api_key=api_key, base_url=base_url) as client:
+            return client.create_support_ticket(
+                question_type=question_type,
+                subject=subject,
+                description=description,
+                account_id=account_id,
+                resource_name=resource_name,
+                error_reason=error_reason,
+                request_id=request_id,
+                user_confirmed=user_confirmed,
+            )
+
     def create_rest_client(self):
         if not hasattr(self, "holder") and self._managed_config is not None:
             return _LazyManagedRestClient(

--- a/src/fireworks/training/sdk/fireworks_client.py
+++ b/src/fireworks/training/sdk/fireworks_client.py
@@ -43,6 +43,14 @@ class _TransientOperationPollError(Exception):
 
 _RESOURCE_ID_RE = re.compile(r"^[a-z0-9-]+$")
 
+_SUPPORT_QUESTION_TYPES = {
+    "job_failure": "SUPPORT_QUESTION_TYPE_JOB_FAILURE",
+    "performance": "SUPPORT_QUESTION_TYPE_PERFORMANCE",
+    "billing": "SUPPORT_QUESTION_TYPE_BILLING",
+    "product_question": "SUPPORT_QUESTION_TYPE_PRODUCT_QUESTION",
+    "other": "SUPPORT_QUESTION_TYPE_OTHER",
+}
+
 # 4-segment checkpoint resource name preferred by promote_checkpoint:
 # accounts/<a>/rlorTrainerJobs/<j>/checkpoints/<c>.
 _CHECKPOINT_NAME_RE = re.compile(
@@ -192,6 +200,61 @@ class FireworksClient(_RestClient):
             additional_headers=additional_headers,
             verify_ssl=verify_ssl,
         )
+
+    def create_support_ticket(
+        self,
+        *,
+        question_type: str,
+        subject: str,
+        description: str,
+        account_id: str | None = None,
+        resource_name: str | None = None,
+        error_reason: str | None = None,
+        request_id: str | None = None,
+        user_confirmed: bool = False,
+    ) -> dict:
+        """Submit reviewed support fields through Fireworks to Pylon."""
+        if not user_confirmed:
+            raise ValueError("user_confirmed=True is required after reviewing the exact support fields")
+        normalized_type = question_type.strip().lower().replace("-", "_")
+        api_question_type = _SUPPORT_QUESTION_TYPES.get(normalized_type)
+        if api_question_type is None:
+            allowed = ", ".join(sorted(_SUPPORT_QUESTION_TYPES))
+            raise ValueError(f"invalid question_type {question_type!r}; expected one of: {allowed}")
+
+        support_account_id = (account_id or "").removeprefix("accounts/")
+        if not support_account_id and resource_name:
+            resource_parts = resource_name.split("/")
+            if len(resource_parts) >= 3 and resource_parts[0] == "accounts":
+                support_account_id = resource_parts[1]
+        if not support_account_id:
+            support_account_id = self.account_id
+
+        payload: dict[str, Any] = {
+            "parent": f"accounts/{support_account_id}",
+            "questionType": api_question_type,
+            "subject": subject,
+            "description": description,
+            "userConfirmed": True,
+        }
+        if resource_name:
+            payload["resourceName"] = resource_name
+        if error_reason:
+            payload["errorReason"] = error_reason
+        if request_id:
+            payload["requestId"] = request_id
+
+        resp = self._post(f"/v1/accounts/{support_account_id}/supportTickets", json=payload)
+        if not resp.is_success:
+            raise RuntimeError(
+                format_sdk_error(
+                    "Failed to create support ticket",
+                    parse_api_error(resp),
+                    "Review the submitted fields or use https://support.fireworks.ai/.",
+                    docs_url=DOCS_SDK,
+                )
+            )
+        return resp.json()
 
     def model_is_moe(self, model: str) -> bool:
         """Return whether ``model`` is a mixture-of-experts model.

--- a/src/fireworks/training/sdk/tests/test_support.py
+++ b/src/fireworks/training/sdk/tests/test_support.py
@@ -1,0 +1,130 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from fireworks.training.sdk.client import FiretitanServiceClient
+from fireworks.training.sdk.fireworks_client import FireworksClient
+
+
+def _response(status_code: int, payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload,
+        request=httpx.Request("POST", "https://api.test/v1/accounts/acme/supportTickets"),
+    )
+
+
+def test_create_support_ticket_requires_confirmation() -> None:
+    client = FireworksClient(api_key="test-key", base_url="https://api.test")
+    client._post = MagicMock()
+
+    with pytest.raises(ValueError, match="user_confirmed=True is required"):
+        client.create_support_ticket(
+            question_type="job_failure",
+            subject="Training failed",
+            description="Reviewed description",
+        )
+
+    client._post.assert_not_called()
+    client.close()
+
+
+def test_create_support_ticket_submits_reviewed_fields() -> None:
+    client = FireworksClient(api_key="test-key", base_url="https://api.test")
+    client._post = MagicMock(
+        return_value=_response(
+            200,
+            {
+                "submissionStatus": "SUBMISSION_STATUS_SUBMITTED",
+                "ticketId": "issue_123",
+            },
+        )
+    )
+
+    result = client.create_support_ticket(
+        question_type="job-failure",
+        subject="Training failed",
+        description="Reviewed description",
+        resource_name="accounts/acme/trainingSessions/session-1/trainingRuns/run-1",
+        error_reason="BACKEND_ERROR",
+        request_id="req-123",
+        user_confirmed=True,
+    )
+
+    client._post.assert_called_once_with(
+        "/v1/accounts/acme/supportTickets",
+        json={
+            "parent": "accounts/acme",
+            "questionType": "SUPPORT_QUESTION_TYPE_JOB_FAILURE",
+            "subject": "Training failed",
+            "description": "Reviewed description",
+            "resourceName": "accounts/acme/trainingSessions/session-1/trainingRuns/run-1",
+            "errorReason": "BACKEND_ERROR",
+            "requestId": "req-123",
+            "userConfirmed": True,
+        },
+    )
+    assert result["ticketId"] == "issue_123"
+    client.close()
+
+
+def test_create_support_ticket_rejects_unknown_question_type() -> None:
+    client = FireworksClient(api_key="test-key", base_url="https://api.test")
+    client._post = MagicMock()
+
+    with pytest.raises(ValueError, match="invalid question_type"):
+        client.create_support_ticket(
+            question_type="unknown",
+            subject="Training failed",
+            description="Reviewed description",
+            user_confirmed=True,
+        )
+
+    client._post.assert_not_called()
+    client.close()
+
+
+def test_create_support_ticket_reports_api_failure() -> None:
+    client = FireworksClient(api_key="test-key", base_url="https://api.test")
+    client._post = MagicMock(return_value=_response(400, {"error": {"message": "resource is not accessible"}}))
+
+    with pytest.raises(RuntimeError, match="resource is not accessible"):
+        client.create_support_ticket(
+            question_type="job_failure",
+            subject="Training failed",
+            description="Reviewed description",
+            account_id="acme",
+            user_confirmed=True,
+        )
+
+    client.close()
+
+
+def test_training_api_service_client_delegates_to_control_plane(monkeypatch) -> None:
+    seen: dict = {}
+
+    def fake_create_support_ticket(self, **kwargs):
+        seen["base_url"] = self.base_url
+        seen["kwargs"] = kwargs
+        return {"ticketId": "issue_789"}
+
+    monkeypatch.setattr(FireworksClient, "create_support_ticket", fake_create_support_ticket)
+    service = object.__new__(FiretitanServiceClient)
+    service._fireworks_api_key = "test-key"
+    service._managed_base_url = "https://api.test/training/v1/serverless"
+
+    result = service.create_support_ticket(
+        question_type="job_failure",
+        subject="Training run failed",
+        description="Reviewed description",
+        resource_name="accounts/acme/trainingSessions/session-1/trainingRuns/run-1",
+        error_reason="BACKEND_ERROR",
+        request_id="req-789",
+        user_confirmed=True,
+    )
+
+    assert result["ticketId"] == "issue_789"
+    assert seen["base_url"] == "https://api.test"
+    assert seen["kwargs"]["error_reason"] == "BACKEND_ERROR"
+    assert seen["kwargs"]["user_confirmed"] is True


### PR DESCRIPTION
## Summary

* expose the account-scoped Fireworks support endpoint through `FireworksClient.create_support_ticket`
* add a `FiretitanServiceClient.create_support_ticket` convenience path for Training API workflows
* require explicit `user_confirmed=True`
* derive account scope from an explicit account or verified resource name
* preserve existing skill source and UUID metadata on the support request

## Test plan

- [x] confirmation gate
- [x] request serialization and account-scoped URL
- [x] API failure handling
- [x] FiretitanServiceClient delegation
- [x] existing REST metadata propagation
- [x] Ruff checks

## Server dependency

The endpoint is introduced by [fw-ai/fireworks#40348](https://github.com/fw-ai/fireworks/pull/40348). The client can release before the server because unsupported calls fail normally and require explicit invocation.

Made with [Cursor](https://cursor.com)