### PR TITLE
Wait for trainer capacity before rollout GPUs and send MTP fields

### DIFF
--- a/src/fireworks/training/sdk/deployment.py
+++ b/src/fireworks/training/sdk/deployment.py
@@ -168,6 +168,10 @@ class DeploymentConfig:
     """
     skip_shape_validation: bool = False
     disable_speculative_decoding: bool = False
+    draft_model: str | None = None
+    """Speculative-decoding draft model at create time (e.g. ``\"mtp\"``)."""
+    draft_token_count: int | None = None
+    enable_session_affinity: bool | None = None
     extra_args: list[str] | None = None
     extra_values: dict[str, str] | None = None
     annotations: dict[str, str] | None = None
@@ -351,7 +355,7 @@ class DeploymentManager(_RestClient):
         path = f"/v1/accounts/{self.account_id}/deployments?deploymentId={config.deployment_id}"
         if config.skip_shape_validation:
             path = f"{path}&skipShapeValidation=true"
-        if config.disable_speculative_decoding:
+        if config.disable_speculative_decoding and not config.draft_model:
             path = f"{path}&disableSpeculativeDecoding=true"
 
         body = self._build_deployment_body(config)
@@ -433,6 +437,12 @@ class DeploymentManager(_RestClient):
             body["annotations"] = config.annotations
         if config.preemptible:
             body["preemptible"] = True
+        if config.draft_model:
+            body["draftModel"] = config.draft_model
+        if config.draft_token_count is not None:
+            body["draftTokenCount"] = config.draft_token_count
+        if config.enable_session_affinity is not None:
+            body["enableSessionAffinity"] = config.enable_session_affinity
         return body
 
     def _parse_deployment_info(

--- a/src/fireworks/training/sdk/managed.py
+++ b/src/fireworks/training/sdk/managed.py
@@ -206,6 +206,19 @@ class FiretitanProvisioningConfig:
     reservation_target: str | None = None
     """Pin the trainer to a named reservation resource or reservation group."""
 
+    wait_for_trainer_before_deployment: bool = False
+    """Wait for trainer READY before creating the rollout deployment.
+
+    Default overlaps trainer boot with deployment creation. Set true so a
+    queued trainer does not hold serving replicas idle.
+    """
+    draft_model: str | None = None
+    """Speculative-decoding draft model at deploy create (e.g. ``\"mtp\"``)."""
+    draft_token_count: int | None = None
+    """Tokens drafted per step (paired with ``draft_model``)."""
+    enable_session_affinity: bool | None = None
+    """If set, configure session affinity at deploy create time."""
+
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
@@ -548,17 +561,6 @@ def _create_managed_tinker_client(
             started_trainer.job,
             config,
         )
-        deployment_future = None
-        if config.create_deployment:
-            deployment_future = executor.submit(
-                _attach_managed_deployment,
-                deploy_mgr,
-                config,
-                trainer_job_name=started_trainer.job.job_name,
-                deployment_shape=deployment_shape,
-                cmek_resource=cmek_resource,
-            )
-
         reference_future = None
         if reference_config is not None:
             reference_future = executor.submit(
@@ -571,6 +573,18 @@ def _create_managed_tinker_client(
                 hotload_api_url=hotload_api_url,
                 additional_headers=additional_headers,
                 verify_ssl=verify_ssl,
+            )
+        if config.create_deployment and config.wait_for_trainer_before_deployment:
+            trainer_future.result()
+        deployment_future = None
+        if config.create_deployment:
+            deployment_future = executor.submit(
+                _attach_managed_deployment,
+                deploy_mgr,
+                config,
+                trainer_job_name=started_trainer.job.job_name,
+                deployment_shape=deployment_shape,
+                cmek_resource=cmek_resource,
             )
 
         endpoint = trainer_future.result()
@@ -973,6 +987,9 @@ def _create_or_reattach_deployment_result(
         extra_values=config.deployment_extra_values,
         annotations={SDK_MANAGED_ROLLOUT_DEPLOYMENT_ANNOTATION: "true"},
         preemptible=config.preemptible,
+        draft_model=config.draft_model,
+        draft_token_count=config.draft_token_count,
+        enable_session_affinity=config.enable_session_affinity,
     )
     deployment = deploy_mgr.create_or_get(deployment_config)
     if deployment.state not in DEPLOYMENT_SERVING_STATES:

--- a/src/fireworks/training/sdk/tests/test_deployment.py
+++ b/src/fireworks/training/sdk/tests/test_deployment.py
@@ -798,6 +798,20 @@ class TestHotLoadTransitionType:
     def test_preemptible_omitted_when_false(self, deploy_config):
         assert "preemptible" not in DeploymentManager._build_deployment_body(deploy_config)
 
+    def test_speculation_fields_serialized_in_body(self, deploy_config):
+        body = DeploymentManager._build_deployment_body(
+            replace(
+                deploy_config,
+                draft_model="mtp",
+                draft_token_count=3,
+                enable_session_affinity=False,
+            )
+        )
+
+        assert body["draftModel"] == "mtp"
+        assert body["draftTokenCount"] == 3
+        assert body["enableSessionAffinity"] is False
+
     @pytest.mark.parametrize(
         ("configured", "expected"),
         [("ASYNC", "ASYNC"), ("SYNC", "SYNC"), ("sync", "SYNC"), (" async ", "ASYNC")],

--- a/src/fireworks/training/sdk/tests/test_managed_reference.py
+++ b/src/fireworks/training/sdk/tests/test_managed_reference.py
@@ -606,6 +606,84 @@ class TestManagedProvisioning:
         assert handle.reference_handle.trainer_endpoint.job_id == "reference-job"
         assert handle.deployment.deployment_id == "deployment-1"
 
+    def test_wait_for_trainer_before_deployment_serializes_rollout_create(self, monkeypatch):
+        events: list[str] = []
+
+        class FakeTrainerManager:
+            account_id = "acct"
+
+            def resolve_training_profile(self, training_shape_id):
+                return SimpleNamespace(
+                    training_shape_version=f"{training_shape_id}/versions/v1",
+                    deployment_shape="deployment-shape/versions/v1",
+                    max_supported_context_length=32768,
+                    trainer_mode="POLICY_TRAINER",
+                )
+
+            def create(self, config):
+                events.append("policy_create")
+                return CreatedTrainerJob(
+                    job_name="accounts/acct/rlorTrainerJobs/policy-job",
+                    job_id="policy-job",
+                )
+
+            def try_get(self, job_id):
+                return None
+
+            def wait_for_ready(self, job_id, *, job_name, timeout_s, pending_timeout_s):
+                events.append("policy_wait_done")
+                return TrainerServiceEndpoint(
+                    job_name=job_name,
+                    job_id=job_id,
+                    base_url="https://trainer.test",
+                )
+
+        class FakeTrainingClient:
+            def _attach_sampler_backend(self, sampler_backend):
+                return None
+
+        class FakeServiceClient:
+            def __init__(self, *, base_url, api_key):
+                pass
+
+            def create_training_client(self, *, base_model, lora_rank, user_metadata):
+                return FakeTrainingClient()
+
+            def _attach_sampler_backend(self, sampler_backend):
+                return None
+
+        def fake_attach_deployment(
+            _deploy_mgr,
+            _config,
+            *,
+            trainer_job_name,
+            deployment_shape,
+            cmek_resource=None,
+        ):
+            events.append(f"deployment_start:{trainer_job_name}")
+            return SimpleNamespace(deployment_id="deployment-1"), object(), False, True
+
+        monkeypatch.setattr(
+            managed_module, "_build_resource_managers", lambda **_k: (FakeTrainerManager(), object())
+        )
+        monkeypatch.setattr(managed_module, "_attach_managed_deployment", fake_attach_deployment)
+        monkeypatch.setattr(managed_module, "FiretitanServiceClient", FakeServiceClient)
+
+        handle = managed_module._create_managed_tinker_client(
+            api_key="fw-key",
+            config=_policy_config(
+                trainer_job_id=None,
+                wait_for_trainer_before_deployment=True,
+            ),
+        )
+
+        assert events[:3] == [
+            "policy_create",
+            "policy_wait_done",
+            "deployment_start:accounts/acct/rlorTrainerJobs/policy-job",
+        ]
+        assert handle.deployment.deployment_id == "deployment-1"
+
     def test_full_param_reference_without_shape_auto_selects_at_trainer_create(self):
         reference = _reference_managed_config(
             _policy_config(reference_training_shape_id=None),


### PR DESCRIPTION
Superseded by the authoritative staging PR: https://github.com/fw-ai/fireworks/pull/47925

This SDK change is paired with the official cookbook source in `fw-ai/fireworks/public-repos/cookbook`. Both generated public repositories are updated by promotion automation after the staging PR merges.